### PR TITLE
Avoid receiving an array by value in Segtree init

### DIFF
--- a/Codes/Data structures/Segtree iterative.cpp
+++ b/Codes/Data structures/Segtree iterative.cpp
@@ -8,7 +8,7 @@ struct Seg {
   }
 
   template <class Arr>
-  Seg(int l, int r, Arr a) : f(l), n(r - l + 1), tree(2 * n) {
+  Seg(int l, int r, Arr& a) : f(l), n(r - l + 1), tree(2 * n) {
     fore (i, 0, n)
       tree[i + n] = T(a[l + i]);
     fore (i, n, 0)

--- a/Codes/Data structures/Segtree.cpp
+++ b/Codes/Data structures/Segtree.cpp
@@ -5,7 +5,7 @@ struct Seg {
   T val;
 
   template <class Arr>
-  Seg(int l, int r, Arr a) : l(l), r(r), left(0), right(0) {
+  Seg(int l, int r, Arr& a) : l(l), r(r), left(0), right(0) {
     if (l == r) {
       val = T(a[l]);
       return;


### PR DESCRIPTION
This could lead to O(n^2) initialization because a copy is made for every node of the segment tree

Without the reference
https://codeforces.com/contest/1927/submission/245364796

With the reference
https://codeforces.com/contest/1927/submission/245150513